### PR TITLE
Proto parser demo generator and changed the code structure so that it is less circular

### DIFF
--- a/proto_parser/demo/BUILD
+++ b/proto_parser/demo/BUILD
@@ -4,6 +4,7 @@ cc_binary(
   deps = [
     "//proto:event_predicate_cc_proto",
     "//src:proto_value"
+    "//src:proto_parser"
   ],
   data = glob(["proto_text/*.txt"])
 )

--- a/proto_parser/demo/BUILD
+++ b/proto_parser/demo/BUILD
@@ -1,0 +1,18 @@
+cc_binary(
+  name = "demo_generator",
+  srcs = ["demo_generator.cc"],
+  deps = [
+    "//proto:event_predicate_cc_proto",
+    "//src:proto_value"
+  ],
+  data = glob(["proto_text/*.txt"])
+)
+
+cc_binary(
+  name = "demo",
+  srcs = ["demo.cc"],
+  deps = [
+    "//proto:event_predicate_cc_proto",
+    "//src:proto_value",
+  ],
+)

--- a/proto_parser/demo/BUILD
+++ b/proto_parser/demo/BUILD
@@ -3,10 +3,10 @@ cc_binary(
   srcs = ["demo_generator.cc"],
   deps = [
     "//proto:event_predicate_cc_proto",
-    "//src:proto_value"
+    "//src:proto_value",
     "//src:proto_parser"
   ],
-  data = glob(["proto_text/*.txt"])
+  data = glob(["proto_texts/*.txt"])
 )
 
 cc_binary(

--- a/proto_parser/demo/BUILD
+++ b/proto_parser/demo/BUILD
@@ -16,4 +16,5 @@ cc_binary(
     "//proto:event_predicate_cc_proto",
     "//src:proto_value",
   ],
+  data = glob(["proto_texts/*.txt"])
 )

--- a/proto_parser/demo/demo_generator.cc
+++ b/proto_parser/demo/demo_generator.cc
@@ -18,8 +18,6 @@
 #include <fstream>
 
 #include "../src/proto_value.h"
-// #include "../src/primitive_value.h"
-// #include "../src/message_value.h"
 #include "../src/proto_parser.h"
 #include "proto/event_predicate.pb.h"
 

--- a/proto_parser/demo/demo_generator.cc
+++ b/proto_parser/demo/demo_generator.cc
@@ -18,23 +18,88 @@
 #include <fstream>
 
 #include "../src/proto_value.h"
+// #include "../src/primitive_value.h"
+// #include "../src/message_value.h"
+#include "../src/proto_parser.h"
 #include "proto/event_predicate.pb.h"
 
 using ::wireless_android_play_analytics::ProtoValue;
+using ::wireless_android_play_analytics::MessageValue;
+using ::wireless_android_play_analytics::PrimitiveValue;
 using ::wireless_android_play_analytics::EventPredicate;
+using ::wireless_android_play_analytics::ProtoParser;
+
+std::string Generate(MessageValue* Message);
 
 int main() {
-  std::ifstream ifs("demo/proto_texts/original_proto_text.txt");
+  std::ifstream ifs;
   std::string text_proto;
   EventPredicate event_predicate;
 
+  ifs.open("demo/proto_texts/original_proto_text.txt");
+
+  assert(ifs.good());
+
   while (ifs.good()) {
-    std::getline(ifs, text_proto);
+    std::string tmp;
+    std::getline(ifs, tmp);
+    text_proto += tmp + "\n";
   }
 
-  std::unique_ptr<ProtoValue> message = ProtoValue::Create(text_proto, 
-      event_predicate);
-  
-  std::cout << message.get()->PrintToTextProto();
+  ProtoParser parser(text_proto);
+
+  for(int i = 0; i < 10; ++i) {
+    std::unique_ptr<ProtoValue> message = parser.Create(event_predicate);
+    std::ofstream outs;
+    outs.open("demo/proto_texts/proto_text(" + std::to_string(i) +").txt");
+    outs << Generate(static_cast<MessageValue*>(message.get()));
+  }
+
   return 0;
+}
+
+std::string Generate(MessageValue* message) {
+  const std::vector<ProtoValue*>& message_fields = message->GetFieldsMutable();
+  absl::variant<double, float, int, unsigned int, int64_t, uint64_t, bool, 
+      const google::protobuf::EnumValueDescriptor*, std::string> val;
+
+  // Generate random int_comparator.
+  MessageValue* event_matcher = static_cast<MessageValue*>(message_fields[0]);
+  if (rand() % 2) {
+    std::unique_ptr<ProtoValue> int_comparator = 
+        absl::make_unique<PrimitiveValue>("int_comparator", 1, 8);
+    
+    PrimitiveValue* int_comparator_ptr = 
+        static_cast<PrimitiveValue*>(int_comparator.get());
+
+    // Generate comment
+    if (rand() % 2) {
+      int_comparator_ptr->SetCommentBehindField("# randomly generated comment");
+    }
+    std::vector<std::string> comments_above_field;
+    int count = 0;
+    while(rand() % 2) {
+      comments_above_field.push_back("# randomly generated comment " + 
+          std::to_string(count++));
+    }
+    int_comparator_ptr->SetCommentAboveField(comments_above_field);
+
+    int input = rand() % 1000;
+    val = input;
+    int_comparator_ptr->SetVal(val);
+
+    event_matcher->AddField(std::move(int_comparator));
+  }
+
+  // Randomly erase leaf_ui_predicates.
+  MessageValue* ui_element_path_predicate = static_cast<MessageValue*>(
+      message_fields[2]);
+  if (rand() % 2) {
+    ui_element_path_predicate->DeleteField(2);
+  }
+  if (rand() % 2) {
+    ui_element_path_predicate->DeleteField(1);
+  }
+  
+  return message->PrintToTextProto();
 }

--- a/proto_parser/demo/demo_generator.cc
+++ b/proto_parser/demo/demo_generator.cc
@@ -1,0 +1,40 @@
+/*
+*   Copyright 2020 Google LLC
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       https://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*/
+
+#include <filesystem>
+#include <fstream>
+
+#include "../src/proto_value.h"
+#include "proto/event_predicate.pb.h"
+
+using ::wireless_android_play_analytics::ProtoValue;
+using ::wireless_android_play_analytics::EventPredicate;
+
+int main() {
+  std::ifstream ifs("demo/proto_texts/original_proto_text.txt");
+  std::string text_proto;
+  EventPredicate event_predicate;
+
+  while (ifs.good()) {
+    std::getline(ifs, text_proto);
+  }
+
+  std::unique_ptr<ProtoValue> message = ProtoValue::Create(text_proto, 
+      event_predicate);
+  
+  std::cout << message.get()->PrintToTextProto();
+  return 0;
+}

--- a/proto_parser/demo/proto_texts/original_proto_text.txt
+++ b/proto_parser/demo/proto_texts/original_proto_text.txt
@@ -1,0 +1,35 @@
+# comment
+# to
+# save
+
+# Condition 1
+event_matcher {
+  input_field: "PlayExtension.store.click"
+}
+# Condition 2
+event_matcher {
+  input_field: "PlayExtension.log_source"
+  int_comparator: 65  # WEB_STORE
+}
+# Condition 3
+ui_element_path_predicate {
+  ui_element_type: STORE_UI_ELEMENT
+  # Condition 3.1
+  leaf_ui_predicate {
+    # ...
+    ui_element_type: STORE_UI_ELEMENT
+    ui_element_matcher {
+      input_field: "type"
+      int_comparator: 7305  # AUTHENTICATION_OPT_OUT_CHECKED
+    }
+  }
+  # Condition 3.2
+  index_ui_matcher {
+    ui_element_type: STORE_UI_ELEMENT
+    index: -2
+    ui_element_matcher {
+      input_field: "type"
+      int_comparator: 1  # SOMETHING
+    }
+  }
+}

--- a/proto_parser/proto/BUILD
+++ b/proto_parser/proto/BUILD
@@ -11,3 +11,13 @@ cc_proto_library(
     name = "example_cc_proto",
     deps = [":example_proto"],
 )
+
+proto_library(
+    name = "event_predicate_proto",
+    srcs = ["event_predicate.proto"],
+)
+
+cc_proto_library(
+    name = "event_predicate_cc_proto",
+    deps = [":event_predicate_proto"],
+)

--- a/proto_parser/proto/event_predicate.proto
+++ b/proto_parser/proto/event_predicate.proto
@@ -1,0 +1,51 @@
+syntax = "proto2";
+
+package wireless_android_play_analytics;
+
+// Next tag: 3
+message EventPredicate {
+  // Next tag: 4
+  message MessageMatcher {
+    optional string input_field = 1;
+    optional int64 int_comparator = 2;
+  }
+
+  // Next tag: 3
+  message UiElementPredicate {
+    // The type of UI element proto message, e.g. store UI element, movie UI
+    // element, etc.
+    optional UiElementType ui_element_type = 1;
+
+    // The matching rule for the UI element. Multiple ui_element_matcher are
+    // AND'ed.
+    repeated MessageMatcher ui_element_matcher = 2;
+  }
+
+  // Next tag: 4
+  enum UiElementType {
+    UNKNOWN_UI_ELEMENT = 0;
+    STORE_UI_ELEMENT = 1;
+    MOVIE_UI_ELEMENT = 2;
+    PHOTO_UI_ELEMENT = 3;
+  }
+
+  // Next tag: 4
+  message IndexUiMatcher {
+    optional UiElementType ui_element_type = 1;
+    optional int32 index = 2;
+    optional MessageMatcher ui_element_matcher = 3;
+  }
+
+  message UiElementPathPredicate {
+    optional UiElementPredicate leaf_ui_predicate = 1;
+    optional UiElementType ui_element_type = 2;
+    repeated IndexUiMatcher index_ui_matcher = 3;
+  }
+  // Defines the rules to match GWSLogEntryProto. Multiple event_matcher are
+  // AND'ed.
+  repeated MessageMatcher event_matcher = 1;
+
+  // Defines the rules to match UiElementPath. Multiple UiElementPath are
+  // OR'ed.
+  repeated UiElementPathPredicate ui_element_path_predicate = 2;
+}

--- a/proto_parser/src/BUILD
+++ b/proto_parser/src/BUILD
@@ -14,7 +14,8 @@ cc_library(
 cc_library(
     name = "proto_value",
     srcs = ["proto_value.cc"],
-    hdrs = ["proto_value.h", "proto_parser.h", "message_value.h", "primitive_value.h"],
+    hdrs = ["proto_value.h", "proto_parser.h", "message_value.h", 
+            "primitive_value.h"],
     deps = ["@com_google_gtest//:gtest",
             "@com_google_absl//absl/types:variant",
             "@com_google_absl//absl/strings",

--- a/proto_parser/src/BUILD
+++ b/proto_parser/src/BUILD
@@ -3,24 +3,24 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 cc_library(
-    name = "proto_parser",
-    srcs = ["proto_parser.cc"],
-    hdrs = ["proto_parser.h"],
-    deps = ["proto_value",
-            "primitive_value",
-            "message_value"]
-)
-
-cc_library(
     name = "proto_value",
     srcs = ["proto_value.cc"],
-    hdrs = ["proto_value.h", "proto_parser.h", "message_value.h", 
-            "primitive_value.h"],
+    hdrs = ["proto_value.h"],
     deps = ["@com_google_gtest//:gtest",
             "@com_google_absl//absl/types:variant",
             "@com_google_absl//absl/strings",
             "@com_google_absl//absl/container:flat_hash_map",
             "@com_google_protobuf//:protobuf"],
+)
+
+cc_test(
+    name = "proto_value_test",
+    srcs = ["proto_value_test.cc"],
+    deps = [
+        "proto_parser", 
+        "proto_value",
+        "//proto:example_cc_proto"
+    ],
 )
 
 cc_library(
@@ -37,12 +37,11 @@ cc_library(
     deps = ["proto_value"]
 )
 
-cc_test(
-    name = "proto_value_test",
-    srcs = ["proto_value_test.cc"],
-    deps = [
-        "proto_parser", 
-        "proto_value",
-        "//proto:example_cc_proto"
-    ],
+cc_library(
+    name = "proto_parser",
+    srcs = ["proto_parser.cc"],
+    hdrs = ["proto_parser.h"],
+    deps = ["proto_value",
+            "primitive_value",
+            "message_value"]
 )

--- a/proto_parser/src/message_value.h
+++ b/proto_parser/src/message_value.h
@@ -37,8 +37,17 @@ class MessageValue : public ProtoValue {
   // Gets all the fields of the current Message with intention to modify it.
   std::vector<ProtoValue*> GetFieldsMutable();
 
-  // Appends a field to the back of fields and fields mutable
+  // Appends a field to the back of fields and fields mutable.
   void AddField(std::unique_ptr<ProtoValue> field);
+
+  // Deletes the field at a specified index.
+  bool DeleteField(size_t idx) {
+    if (idx >= fields_.size()) {
+      return false;
+    }
+    fields_.erase(fields_.begin() + idx);
+    return true;
+  }
 
   // Sorts the fields_ vector.
   void SortFields() {

--- a/proto_parser/src/primitive_value.cc
+++ b/proto_parser/src/primitive_value.cc
@@ -72,6 +72,8 @@ void PrimitiveValue::SetVal(const
     const google::protobuf::EnumValueDescriptor* input_val = 
         absl::get<const google::protobuf::EnumValueDescriptor*>(val);
     val_as_string_ = input_val->name();
+  } else {
+    val_as_string_ = absl::get<std::string>(val);
   }
 }
 } // namespace wireless_android_play_analytics

--- a/proto_parser/src/proto_parser.cc
+++ b/proto_parser/src/proto_parser.cc
@@ -33,19 +33,18 @@ namespace{
   }
 } // namespace
 
-std::unique_ptr<ProtoValue> ProtoValue::Create(absl::string_view text_proto, 
+std::unique_ptr<ProtoValue> ProtoParser::Create(
     google::protobuf::Message& message) {
   google::protobuf::TextFormat::Parser google_parser;
   google::protobuf::TextFormat::ParseInfoTree tree;
   google_parser.WriteLocationsTo(&tree);
-  google_parser.ParseFromString(std::string(text_proto), &message);
-  ProtoParser proto_parser(text_proto);
+  google_parser.ParseFromString(text_proto_, &message);
   
   // Root Message has no field_name and no indentation.
   std::unique_ptr<ProtoValue> message_val = absl::make_unique<MessageValue>(
       /*field_name=*/"", /*indent_count=*/0, /*field_line=*/0); 
 
-  proto_parser.PopulateFields(message, tree, /*indent_count=*/0, 
+  PopulateFields(message, tree, /*indent_count=*/0, 
       message_val.get());
 
   return message_val;

--- a/proto_parser/src/proto_parser.cc
+++ b/proto_parser/src/proto_parser.cc
@@ -32,6 +32,24 @@ namespace{
     }
   }
 } // namespace
+
+std::unique_ptr<ProtoValue> ProtoValue::Create(absl::string_view text_proto, 
+    google::protobuf::Message& message) {
+  google::protobuf::TextFormat::Parser google_parser;
+  google::protobuf::TextFormat::ParseInfoTree tree;
+  google_parser.WriteLocationsTo(&tree);
+  google_parser.ParseFromString(std::string(text_proto), &message);
+  ProtoParser proto_parser(text_proto);
+  
+  // Root Message has no field_name and no indentation.
+  std::unique_ptr<ProtoValue> message_val = absl::make_unique<MessageValue>(
+      /*field_name=*/"", /*indent_count=*/0, /*field_line=*/0); 
+
+  proto_parser.PopulateFields(message, tree, /*indent_count=*/0, 
+      message_val.get());
+
+  return message_val;
+}
   
 void ProtoParser::PopulateFields(const google::protobuf::Message& message,
     const google::protobuf::TextFormat::ParseInfoTree& tree, int indent_count,

--- a/proto_parser/src/proto_parser.h
+++ b/proto_parser/src/proto_parser.h
@@ -33,6 +33,9 @@ class ProtoParser {
   ProtoParser(absl::string_view text_proto) {
     lines_ = absl::StrSplit(text_proto, '\n');
   }
+
+  static std::unique_ptr<ProtoValue> Create(absl::string_view text_proto, 
+      google::protobuf::Message& message);
   
   // Populates the message with all the fields of the message.
   void PopulateFields(const google::protobuf::Message& message,

--- a/proto_parser/src/proto_parser.h
+++ b/proto_parser/src/proto_parser.h
@@ -30,19 +30,19 @@ class ProtoParser {
 
   ProtoParser() {}
 
-  ProtoParser(absl::string_view text_proto) {
+  ProtoParser(absl::string_view text_proto) 
+    : text_proto_(text_proto){
     lines_ = absl::StrSplit(text_proto, '\n');
   }
 
-  static std::unique_ptr<ProtoValue> Create(absl::string_view text_proto, 
-      google::protobuf::Message& message);
-  
+  std::unique_ptr<ProtoValue> Create(google::protobuf::Message& message);
+
+ private:
+
   // Populates the message with all the fields of the message.
   void PopulateFields(const google::protobuf::Message& message,
     const google::protobuf::TextFormat::ParseInfoTree& tree, int indent_count,
     ProtoValue* proto_value);
-
- private:
 
   // Acquires and populates the comments of a specific field.
   void PopulateComments(int field_loc, ProtoValue* message);
@@ -66,6 +66,8 @@ class ProtoParser {
       int repeated_field_index);
 
   std::vector<std::string> lines_;
+
+  std::string text_proto_;
 };
 
 } // namespace wireless_android_play_analytics

--- a/proto_parser/src/proto_value.cc
+++ b/proto_parser/src/proto_value.cc
@@ -15,8 +15,6 @@
 */
 
 #include "proto_value.h"
-#include "proto_parser.h"
-#include "message_value.h"
 
 namespace wireless_android_play_analytics {
 

--- a/proto_parser/src/proto_value.cc
+++ b/proto_parser/src/proto_value.cc
@@ -24,24 +24,6 @@ std::string ProtoValue::PrintToTextProto() {
   return PrintToTextProtoHelper();
 }
 
-std::unique_ptr<ProtoValue> ProtoValue::Create(absl::string_view text_proto, 
-    google::protobuf::Message& message) {
-  google::protobuf::TextFormat::Parser google_parser;
-  google::protobuf::TextFormat::ParseInfoTree tree;
-  google_parser.WriteLocationsTo(&tree);
-  google_parser.ParseFromString(std::string(text_proto), &message);
-  ProtoParser proto_parser(text_proto);
-  
-  // Root Message has no field_name and no indentation.
-  std::unique_ptr<ProtoValue> message_val = absl::make_unique<MessageValue>(
-      /*field_name=*/"", /*indent_count=*/0, /*field_line=*/0); 
-
-  proto_parser.PopulateFields(message, tree, /*indent_count=*/0, 
-      message_val.get());
-
-  return message_val;
-}
-
 void ProtoValue::SetCommentAboveField(absl::string_view val) {
   comments_above_field_ = absl::StrSplit(val, '\n');
 

--- a/proto_parser/src/proto_value.h
+++ b/proto_parser/src/proto_value.h
@@ -42,9 +42,6 @@ class ProtoValue {
 
   virtual ~ProtoValue() = default;
 
-  static std::unique_ptr<ProtoValue> Create(absl::string_view text_proto, 
-    google::protobuf::Message& message);
-
   // Gets the name of current variable.
   const std::string& GetName() const {
     return field_name_;

--- a/proto_parser/src/proto_value.h
+++ b/proto_parser/src/proto_value.h
@@ -26,6 +26,7 @@
 
 #include "absl/types/variant.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/str_split.h"
 #include "absl/container/flat_hash_map.h"
 
 namespace wireless_android_play_analytics {

--- a/proto_parser/src/proto_value_test.cc
+++ b/proto_parser/src/proto_value_test.cc
@@ -67,13 +67,15 @@ class ProtoValueTest : public ::testing::Test {
  protected:
   
   virtual void SetUp() {
-    message_ = ProtoValue::Create(text_proto, test_);
+    parser_ = ProtoParser(text_proto);
+    message_ = parser_.Create(test_);
     message_val_ = dynamic_cast<MessageValue*>(message_.get());
   }
 
   TestProto test_;
   std::unique_ptr<ProtoValue> message_;
   MessageValue* message_val_;
+  ProtoParser parser_;
 };
 
 TEST_F(ProtoValueTest, PrintToTextProtoTest) {


### PR DESCRIPTION
Written and implemented a demo generator that demonstrates the proto parser's ability to create and destroy fields. Also moved create to proto_parser to prevent circular dependency. 